### PR TITLE
A0-2896: Fix Kustomize variable

### DIFF
--- a/.github/actions/deploy-to-devnet/action.yaml
+++ b/.github/actions/deploy-to-devnet/action.yaml
@@ -13,6 +13,9 @@ inputs:
     required: true
   github_token:
     required: true
+  kustomize_version:
+    required: false
+    default: "5.1.1"
 
 runs:
   using: composite
@@ -42,7 +45,7 @@ runs:
     - name: KUSTOMIZE | Init kustomize
       uses: imranismail/setup-kustomize@v2
       with:
-        kustomize-version: ${{ vars.KUSTOMIZE_VERSION }}
+        kustomize-version: ${{ inputs.kustomize_version }}
 
     - name: KUSTOMIZE | Update docker image tag for squid
       shell: bash

--- a/.github/workflows/build-and-deploy-to-devnet.yml
+++ b/.github/workflows/build-and-deploy-to-devnet.yml
@@ -66,6 +66,7 @@ jobs:
           aws_devnet_access_key_id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws_devnet_secret_access_key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           github_token: ${{ secrets.CI_GH_TOKEN }}
+          kustomize_version: ${{ vars.KUSTOMIZE_VERSION }}
   
   deploy_api:
     name: Deploy API
@@ -83,3 +84,4 @@ jobs:
           aws_devnet_access_key_id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
           aws_devnet_secret_access_key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
           github_token: ${{ secrets.CI_GH_TOKEN }}
+          kustomize_version: ${{ vars.KUSTOMIZE_VERSION }}


### PR DESCRIPTION
Fixed variable in `deploy-to-devnet` action. The problem was that you cannot use `vars` inside actions. `Vars` are supposed to be used in workflows.
To fix that I changed `vars` inside `deploy-to-devnet` action to input. Then input gets its value from workflow in which I finally used `${{ vars.KUSTOMIZE_VERSION }}.`